### PR TITLE
X551CA Supported & Confirmed for working.

### DIFF
--- a/battery/battery_ASUS-G75vw.txt
+++ b/battery/battery_ASUS-G75vw.txt
@@ -16,6 +16,7 @@
 #  ASUS F550L
 #  ASUS N551 (per shutt1e)
 #  ASUS T300LA-DH51T (per maromi)
+#  ASUS X551CA
 
 #Convert 16 bit to 8 bit registers
 into device label EC0 code_regex TAH0,\s+16, replace_matched begin AH00,8,AH01,8, end;


### PR DESCRIPTION
Self testing confirmed this to work, also worked for http://www.insanelymac.com/forum/topic/304255-carls-asus-x551ca-si30403x-yosemite-1010-clover-w-bcm94352hmb-vanilla-install/

![screen shot 2015-07-12 at 11 18 47 pm](https://cloud.githubusercontent.com/assets/479793/8637916/665b3616-28ec-11e5-8a28-164d3bab3549.png)
