### PR TITLE
battery: Add HP 2000 2d11DX

### DIFF
--- a/battery/battery_HP-2000-2d11DX.txt
+++ b/battery/battery_HP-2000-2d11DX.txt
@@ -1,0 +1,158 @@
+into method label B1B2 remove_entry;
+into definitionblock code_regex . insert
+begin
+Method (B1B2, 2, NotSerialized) { Return (Or (Arg0, ShiftLeft (Arg1, 8))) }\n
+end;
+
+into method label B1B4 remove_entry;
+into definitionblock code_regex . insert
+begin
+Method (B1B4, 4, NotSerialized)\n
+{\n
+    Store(Arg3, Local0)\n
+    Or(Arg2, ShiftLeft(Local0, 8), Local0)\n
+    Or(Arg1, ShiftLeft(Local0, 8), Local0)\n
+    Or(Arg0, ShiftLeft(Local0, 8), Local0)\n
+    Return(Local0)\n
+}\n
+end;
+
+# utility methods to read/write buffers from/to EC
+into method label RE1B parent_label H_EC remove_entry;
+into method label RECB parent_label H_EC remove_entry;
+into device label H_EC insert
+begin
+Method (RE1B, 1, NotSerialized)\n
+{\n
+    OperationRegion(ERAM, EmbeddedControl, Arg0, 1)\n
+    Field(ERAM, ByteAcc, NoLock, Preserve) { BYTE, 8 }\n
+    Return(BYTE)\n
+}\n
+Method (RECB, 2, Serialized)\n
+{\n
+    ShiftRight(Arg1, 3, Arg1)\n
+    Name(TEMP, Buffer(Arg1) { })\n
+    Add(Arg0, Arg1, Arg1)\n
+    Store(0, Local0)\n
+    While (LLess(Arg0, Arg1))\n
+    {\n
+        Store(RE1B(Arg0), Index(TEMP, Local0))\n
+        Increment(Arg0)\n
+        Increment(Local0)\n
+    }\n
+    Return(TEMP)\n
+}\n
+end;
+
+#
+# Note: Offsets below into EC are based on the following data in the native DSDT
+#
+#                    OperationRegion (ECF2, EmbeddedControl, Zero, 0xFF)
+#                    Field (ECF2, ByteAcc, Lock, Preserve)
+#                    {
+#                        MBVR,   8,
+#                                Offset (0x06),
+#                        KBLL,   8,
+#                                Offset (0x10),
+#                        BDN0,   56,//10
+#                                Offset (0x18),
+#                        BME0,   8,
+#                                Offset (0x1C),
+#                        DAY0,   8,//1c
+#                        HUR0,   8,//1d
+#                        MIN0,   8,//1e
+#                        SEC0,   8,//1f
+#                        BMNC,   8,//20
+#                        BMN0,   120,//21
+#                        BCT0,   128,//30
+#
+# If the native DSDT has any such data re-organized such that the fields
+# being read with RECB are at a different offset, the offsets below
+# (first param to WECB/RECB) would need to be changed for the DSDT.
+#
+# This is something to watch out for when adapting this patch to another 
+# computer and maybe even after updating to a new BIOS.
+#
+
+# deal with 56-bit BDN0
+into device label H_EC code_regex (BDN0,)\s+(56) replace_matched begin BDNX,%2,//%1%2 end;
+into device label H_EC insert begin Method (RDN0, 0, Serialized) { Return(RECB(0x10,56)) } end;
+into method label GBTI code_regex \(BDN0, replaceall_matched begin (RDN0(), end;
+
+# deal with 128-bit BCT0
+into device label H_EC code_regex (BCT0,)\s+(128) replace_matched begin BCTX,%2,//%1%2 end;
+into device label H_EC insert begin Method (RCT0, 0, Serialized) { Return(RECB(0x30,128)) } end;
+into method label GBTI code_regex \(BCT0, replaceall_matched begin (RCT0(), end;
+
+# not battery related, but in case you want to read the fan
+into device label H_EC code_regex FANR,\s+16 replace_matched begin FNR0,8,FNR1,8 end;
+into method label FRSP parent_label TZ00 code_regex \(\\_SB\.PCI0\.LPCB\.H_EC\.FANR, replace_matched begin (B1B2(\\_SB.PCI0.LPCB.H_EC.FNR0,\\_SB.PCI0.LPCB.H_EC.FNR1), end;
+
+# fix 16-bit registers
+into device label H_EC code_regex BDC0,\s+16, replace_matched begin DC00,8,DC01,8, end;
+into device label H_EC code_regex BFC0,\s+16, replace_matched begin FC00,8,FC01,8, end;
+into device label H_EC code_regex BFC1,\s+16, replace_matched begin FC10,8,FC11,8, end;
+into device label H_EC code_regex BDV0,\s+16, replace_matched begin DV00,8,DV01,8, end;
+into device label H_EC code_regex BDV1,\s+16, replace_matched begin DV10,8,DV11,8, end;
+into device label H_EC code_regex BPR0,\s+16, replace_matched begin PR00,8,PR01,8, end;
+into device label H_EC code_regex BPR1,\s+16, replace_matched begin PR10,8,PR11,8, end;
+into device label H_EC code_regex BRC0,\s+16, replace_matched begin RC00,8,RC01,8, end;
+into device label H_EC code_regex BRC1,\s+16, replace_matched begin RC10,8,RC11,8, end;
+into device label H_EC code_regex BCC0,\s+16, replace_matched begin CC00,8,CC01,8, end;
+into device label H_EC code_regex CV01,\s+16, replace_matched begin VC10,8,VC11,8, end;
+into device label H_EC code_regex CV02,\s+16, replace_matched begin VC20,8,VC21,8, end;
+into device label H_EC code_regex CV03,\s+16, replace_matched begin VC30,8,VC31,8, end;
+into device label H_EC code_regex CV04,\s+16, replace_matched begin VC40,8,VC41,8, end;
+into device label H_EC code_regex BMD0,\s+16, replace_matched begin MD00,8,MD01,8, end;
+into device label H_EC code_regex BMD1,\s+16, replace_matched begin MD10,8,MD11,8, end;
+into device label H_EC code_regex BPV0,\s+16, replace_matched begin PV00,8,PV01,8, end;
+into device label H_EC code_regex BPV1,\s+16, replace_matched begin PV10,8,PV11,8, end;
+into device label H_EC code_regex BSN0,\s+16, replace_matched begin SN00,8,SN01,8, end;
+into device label H_EC code_regex BSN1,\s+16, replace_matched begin SN10,8,SN11,8, end;
+into device label H_EC code_regex BCV0,\s+16, replace_matched begin BV00,8,BV01,8, end;
+into device label H_EC code_regex CRG0,\s+16, replace_matched begin RG00,8,RG01,8, end;
+into device label H_EC code_regex CBT0,\s+16, replace_matched begin BT00,8,BT01,8, end;
+
+# fix 16-bit methods
+into method label GBTI code_regex \(BDC0, replaceall_matched begin (B1B2(DC00,DC01), end;
+into method label BTIF code_regex \(BFC0, replaceall_matched begin (B1B2(FC00,FC01), end;
+into method label ITLB code_regex BFC0, replaceall_matched begin B1B2(FC00,FC01), end;
+into method label GBTI code_regex \(BFC0, replaceall_matched begin (B1B2(FC00,FC01), end;
+into method label _Q09 code_regex \(BFC0, replaceall_matched begin (B1B2(FC00,FC01), end;
+into method label BTIF code_regex \(BFC1, replaceall_matched begin (B1B2(FC10,FC11), end;
+into method label ITLB code_regex \(BFC1, replaceall_matched begin (B1B2(FC10,FC11), end;
+into method label BTIF code_regex \(BDV0, replaceall_matched begin (B1B2(DV00,DV01), end;
+into method label GBTI code_regex \(BDV0, replaceall_matched begin (B1B2(DV00,DV01), end;
+into method label BTIF code_regex \(BDV1, replaceall_matched begin (B1B2(DV10,DV11), end;
+into method label BTST code_regex \(BPR0, replaceall_matched begin (B1B2(PR00,PR01), end;
+into method label GBTI code_regex \(BPR0, replaceall_matched begin (B1B2(PR00,PR01), end;
+into method label BTST code_regex BPR0, replaceall_matched begin B1B2(PR00,PR01), end;
+into method label BTST code_regex BPR1, replaceall_matched begin B1B2(PR10,PR11), end;
+into method label BTST code_regex \(BRC0, replaceall_matched begin (B1B2(RC00,RC01), end;
+into method label GBTI code_regex \(BRC0, replaceall_matched begin (B1B2(RC00,RC01), end;
+into method label _Q09 code_regex BRC0\) replaceall_matched begin B1B2(RC00,RC01)) end;
+into method label BTST code_regex \(BRC1, replaceall_matched begin (B1B2(RC10,RC11), end;
+into method label GBTI code_regex \(BCC0, replaceall_matched begin (B1B2(CC00,CC01), end;
+into method label GBTI code_regex \(CV01, replaceall_matched begin (B1B2(VC10,VC11), end;
+into method label GBTI code_regex \(CV02, replaceall_matched begin (B1B2(VC20,VC21), end;
+into method label GBTI code_regex \(CV03, replaceall_matched begin (B1B2(VC30,VC31), end;
+into method label GBTI code_regex \(CV04, replaceall_matched begin (B1B2(VC40,VC41), end;
+into method label BTIF code_regex \(BMD0, replaceall_matched begin (B1B2(MD00,MD01), end;
+into method label GBTI code_regex \(BMD0, replaceall_matched begin (B1B2(MD00,MD01), end;
+into method label GBTI code_regex BMD0 replaceall_matched begin B1B2(MD00,MD01) end;
+into method label BTIF code_regex \(BMD1, replaceall_matched begin (B1B2(MD10,MD11), end;
+into method label BTST code_regex \(BPV0, replaceall_matched begin (B1B2(PV00,PV01), end;
+into method label GBTI code_regex \(BPV0, replaceall_matched begin (B1B2(PV00,PV01), end;
+into method label BTST code_regex \(BPV1, replaceall_matched begin (B1B2(PV10,PV11), end;
+into method label BTIF code_regex \(BSN0, replaceall_matched begin (B1B2(SN00,SN01), end;
+into method label GBTI code_regex \(BSN0, replaceall_matched begin (B1B2(SN00,SN01), end;
+into method label BTIF code_regex \(BSN1, replaceall_matched begin (B1B2(SN10,SN11), end;
+into method label GBTI code_regex \(BCV0, replaceall_matched begin (B1B2(BV00,BV01), end;
+into method label GBTI code_regex \(CRG0, replaceall_matched begin (B1B2(RG00,RG01), end;
+into method label GBTI code_regex \(CBT0, replaceall_matched begin (B1B2(BT00,BT01), end;
+
+# fix 32-bit registers
+into device label H_EC code_regex BTY0,\s+32 replace_matched begin TY00,8,TY01,8,TY02,8,TY03,8 end;
+
+# fix 32-bit methods
+into method label GBTI code_regex \(BTY0, replaceall_matched begin (B1B4(TY00,TY01,TY02,TY03), end;


### PR DESCRIPTION
Battery for the HP 2000 2d11DX

Specifications:
http://support.hp.com/sg-en/document/c03910864

Product info:
http://support.hp.com/us-en/product/HP-2000-Notebook-PC-series/5375422/model/6412055/product-info

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>