### PR TITLE
Lenovo T470 Battery support patch

### DIFF
--- a/battery/battery_Lenovo-T470.txt
+++ b/battery/battery_Lenovo-T470.txt
@@ -1,0 +1,137 @@
+#Maintained by: RehabMan for: Laptop Patches
+#battery_Lenovo-T470.txt
+
+# created by asakapab0i 2019-12-01
+
+# works for:
+#  Lenovo T470 KabyLake
+
+# Note: This DSDT requires "Fix Mutex with non-zero SyncLevel"
+
+into method label B1B2 remove_entry;
+into definitionblock code_regex . insert
+begin
+Method (B1B2, 2, NotSerialized) { Return(Or(Arg0, ShiftLeft(Arg1, 8))) }\n
+end;
+
+into method label B1B4 remove_entry;
+into definitionblock code_regex . insert
+begin
+Method (B1B4, 4, NotSerialized)\n
+{\n
+    Store(Arg3, Local0)\n
+    Or(Arg2, ShiftLeft(Local0, 8), Local0)\n
+    Or(Arg1, ShiftLeft(Local0, 8), Local0)\n
+    Or(Arg0, ShiftLeft(Local0, 8), Local0)\n
+    Return(Local0)\n
+}\n
+end;
+
+into device label EC code_regex HWAC,\s+16, replace_matched begin HWC0,8,HWC1,8, end;
+into method label OWAK code_regex \(\\_SB\.PCI0\.LPCB\.EC\.HWAC, replaceall_matched begin (B1B2(\\_SB.PCI0.LPCB.EC.HWC0,\\_SB.PCI0.LPCB.EC.HWC1), end;
+into method label _L17 code_regex \(\\_SB\.PCI0\.LPCB\.EC\.HWAC, replaceall_matched begin (B1B2(\\_SB.PCI0.LPCB.EC.HWC0,\\_SB.PCI0.LPCB.EC.HWC1), end;
+
+# Modify variables
+into device label EC code_regex SBRC,\s+16, replace_matched begin BR00,8,BR01,8, end;
+into device label EC code_regex SBFC,\s+16, replace_matched begin BF00,8,BF01,8, end;
+into device label EC code_regex SBAC,\s+16, replace_matched begin BA00,8,BA01,8, end;
+into device label EC code_regex SBVO,\s+16, replace_matched begin BV00,8,BV01,8, end;
+into device label EC code_regex SBBM,\s+16, replace_matched begin BB00,8,BB01,8, end;
+into device label EC code_regex SBDC,\s+16, replace_matched begin BD00,8,BD01,8, end;
+into device label EC code_regex SBDV,\s+16, replace_matched begin SB00,8,SB01,8, end;
+into device label EC code_regex SBSN,\s+16 replace_matched begin BS00,8,BS01,8 end;
+
+
+#Thinkpad T470 specifics
+into device label EC code_regex SBAE,\s+16 replace_matched begin BAE0,8,BAE1,8 end;
+into device label EC code_regex SBRS,\s+16 replace_matched begin BRS0,8,BRS1,8 end;
+into device label EC code_regex SBAF,\s+16 replace_matched begin BAF0,8,BAF1,8 end;
+into device label EC code_regex SBBS,\s+16 replace_matched begin BBS0,8,BBS1,8 end;
+into device label EC code_regex SBMD,\s+16 replace_matched begin BMD0,8,BMD1,8 end;
+into device label EC code_regex SBCC,\s+16 replace_matched begin BCC0,8,BCC1,8 end;
+into device label EC code_regex SBOM,\s+16 replace_matched begin BOM0,8,BOM1,8 end;
+into device label EC code_regex SBSI,\s+16 replace_matched begin BSI0,8,BSI1,8 end;
+into device label EC code_regex SBDT,\s+16 replace_matched begin BDT0,8,BDT1,8 end;
+
+
+into method label GBST code_regex \(SBRC, replaceall_matched begin (B1B2(BR00,BR01), end;
+into method label GBIF code_regex \(SBFC, replaceall_matched begin (B1B2(BF00,BF01), end;
+into method label GBIX code_regex \(SBFC, replaceall_matched begin (B1B2(BF00,BF01), end;
+into method label GBST code_regex \(SBAC, replaceall_matched begin (B1B2(BA00,BA01), end;
+into method label GBST code_regex \(SBVO, replaceall_matched begin (B1B2(BV00,BV01), end;
+into method label GBIF code_regex \(SBBM, replaceall_matched begin (B1B2(BB00,BB01), end;
+into method label GBIX code_regex \(SBBM, replaceall_matched begin (B1B2(BB00,BB01), end;
+into method label GBIF code_regex \(SBDC, replaceall_matched begin (B1B2(BD00,BD01), end;
+into method label GBIX code_regex \(SBDC, replaceall_matched begin (B1B2(BD00,BD01), end;
+into method label GBIF code_regex \(SBDV, replaceall_matched begin (B1B2(SB00,SB01), end;
+into method label GBIX code_regex \(SBDV, replaceall_matched begin (B1B2(SB00,SB01), end;
+into method label GBIF code_regex SBDV, replaceall_matched begin B1B2(SB00,SB01), end;
+
+into method label GBIF code_regex \(SBSN, replaceall_matched begin (B1B2(BS00,BS01), end;
+into method label GBIX code_regex \(SBSN, replaceall_matched begin (B1B2(BS00,BS01), end;
+
+#Thinkpad T470 specifics
+into method label GBIX code_regex \(SBCC, replaceall_matched begin (B1B2(BCC0,BCC1), end;
+
+
+into device label EC code_regex SBCH,\s+32 replace_matched begin SH00,8,SH01,8,SH02,8,SH03,8 end;
+into method label GBIF code_regex \(SBCH, replaceall_matched begin (B1B4(SH00,SH01,SH02,SH03), end;
+
+into device label EC code_regex (SBMN,)\s+(128) replace_matched begin BMNX,%2,//%1%2 end;
+into device label EC code_regex (SBDN,)\s+(128) replace_matched begin BDNX,%2,//%1%2 end;
+
+into method label RE1B parent_label EC remove_entry;
+into method label RECB parent_label EC remove_entry;
+into device label EC insert
+begin
+Method (RE1B, 1, NotSerialized)\n
+// Arg0 - offset in bytes from zero-based EC\n
+{\n
+    OperationRegion(ERAM, EmbeddedControl, Arg0, 1)\n
+    Field(ERAM, ByteAcc, NoLock, Preserve) { BYTE, 8 }\n
+    Return(BYTE)\n
+}\n
+Method (RECB, 2, Serialized)\n
+// Arg0 - offset in bytes from zero-based EC\n
+// Arg1 - size of buffer in bits\n
+{\n
+    ShiftRight(Arg1, 3, Arg1)\n
+    Name(TEMP, Buffer(Arg1) { })\n
+    Add(Arg0, Arg1, Arg1)\n
+    Store(0, Local0)\n
+    While (LLess(Arg0, Arg1))\n
+    {\n
+        Store(RE1B(Arg0), Index(TEMP, Local0))\n
+        Increment(Arg0)\n
+        Increment(Local0)\n
+    }\n
+    Return(TEMP)\n
+}\n
+end;
+
+into method label GBIF code_regex \(SBMN, replaceall_matched begin (RECB(0xA0,128), end;
+into method label GBIF code_regex \(SBDN, replaceall_matched begin (RECB(0xA0,128), end;
+
+# added for E470 KabyLake
+# Fix HWAK Read
+into method label \_WAK code_regex \(\\\_SB.PCI0.LPC.EC.HWAK replaceall_matched begin (B1B2(\\_SB.PCI0.LPC.EC.HWK0,\\_SB.PCI0.LPC.EC.HWK1) end;
+into method label _WAK code_regex \(\\\_SB.PCI0.LPC.EC.HWAK replaceall_matched begin (B1B2(\\_SB.PCI0.LPC.EC.HWK0,\\_SB.PCI0.LPC.EC.HWK1) end;
+
+# Fix HWAK Write
+into method label \_WAK code_regex Store\s\(0x00,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
+begin
+Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
+end;
+into method label _WAK code_regex Store\s\(0x00,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
+begin
+Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
+end;
+
+into method label \_WAK code_regex Store\s\(Zero,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
+begin
+Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
+end;
+into method label _WAK code_regex Store\s\(Zero,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
+begin
+Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
+end;

--- a/battery/battery_Lenovo-T470.txt
+++ b/battery/battery_Lenovo-T470.txt
@@ -66,9 +66,10 @@ into method label GBIX code_regex \(SBDC, replaceall_matched begin (B1B2(BD00,BD
 into method label GBIF code_regex \(SBDV, replaceall_matched begin (B1B2(SB00,SB01), end;
 into method label GBIX code_regex \(SBDV, replaceall_matched begin (B1B2(SB00,SB01), end;
 into method label GBIF code_regex SBDV, replaceall_matched begin B1B2(SB00,SB01), end;
+into method label GBIX code_regex SBDV, replaceall_matched begin B1B2(SB00,SB01), end;
+into method label GBIX code_regex SBDV replaceall_matched begin (B1B2(SB00,SB01)), end;
+into method label GBIX code_regex \(SBDV replaceall_matched begin (B1B2(SB00,SB01) end;
 
-into method label GBIF code_regex \(SBSN, replaceall_matched begin (B1B2(BS00,BS01), end;
-into method label GBIX code_regex \(SBSN, replaceall_matched begin (B1B2(BS00,BS01), end;
 
 #Thinkpad T470 specifics
 into method label GBIX code_regex \(SBCC, replaceall_matched begin (B1B2(BCC0,BCC1), end;
@@ -76,6 +77,7 @@ into method label GBIX code_regex \(SBCC, replaceall_matched begin (B1B2(BCC0,BC
 
 into device label EC code_regex SBCH,\s+32 replace_matched begin SH00,8,SH01,8,SH02,8,SH03,8 end;
 into method label GBIF code_regex \(SBCH, replaceall_matched begin (B1B4(SH00,SH01,SH02,SH03), end;
+into method label GBIX code_regex \(SBCH, replaceall_matched begin (B1B4(SH00,SH01,SH02,SH03), end;
 
 into device label EC code_regex (SBMN,)\s+(128) replace_matched begin BMNX,%2,//%1%2 end;
 into device label EC code_regex (SBDN,)\s+(128) replace_matched begin BDNX,%2,//%1%2 end;
@@ -111,27 +113,5 @@ end;
 
 into method label GBIF code_regex \(SBMN, replaceall_matched begin (RECB(0xA0,128), end;
 into method label GBIF code_regex \(SBDN, replaceall_matched begin (RECB(0xA0,128), end;
-
-# added for E470 KabyLake
-# Fix HWAK Read
-into method label \_WAK code_regex \(\\\_SB.PCI0.LPC.EC.HWAK replaceall_matched begin (B1B2(\\_SB.PCI0.LPC.EC.HWK0,\\_SB.PCI0.LPC.EC.HWK1) end;
-into method label _WAK code_regex \(\\\_SB.PCI0.LPC.EC.HWAK replaceall_matched begin (B1B2(\\_SB.PCI0.LPC.EC.HWK0,\\_SB.PCI0.LPC.EC.HWK1) end;
-
-# Fix HWAK Write
-into method label \_WAK code_regex Store\s\(0x00,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
-begin
-Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
-end;
-into method label _WAK code_regex Store\s\(0x00,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
-begin
-Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
-end;
-
-into method label \_WAK code_regex Store\s\(Zero,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
-begin
-Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
-end;
-into method label _WAK code_regex Store\s\(Zero,\s\\\_SB.PCI0.LPC.EC.HWAK\) replaceall_matched
-begin
-Store(Zero,\\_SB.PCI0.LPC.EC.HWK0) Store(Zero,\\_SB.PCI0.LPC.EC.HWK1)
-end;
+into method label GBIX code_regex \(SBMN, replaceall_matched begin (RECB(0xA0,128), end;
+into method label GBIX code_regex \(SBDN, replaceall_matched begin (RECB(0xA0,128), end;


### PR DESCRIPTION
Battery support for Thinkpad T470 Kaby Lake.
MacIASL Options
- ACPI 6.2a

Here's the DSDT.aml for compilation.

[DSDT.aml.zip](https://github.com/RehabMan/Laptop-DSDT-Patch/files/3907477/DSDT.aml.zip)
