### PR TITLE
Tested on hp pavilion 15-cs0975nd

### DIFF
--- a/battery/battery_HP-Pavilion-n012tx.txt
+++ b/battery/battery_HP-Pavilion-n012tx.txt
@@ -12,6 +12,7 @@
 #  HP Pavilion 15-n096ea (per oscarr)
 #  HP Pavilion 17-f078nf (per xdevillived666)
 #  HP Pavilion 15-cb050od (per github/Jahazielg)
+#  HP Pavilion 15-cs0975nd (test by JJJ W.)
 
 into method label B1B2 remove_entry;
 into definitionblock code_regex . insert


### PR DESCRIPTION
Works properly, I used ACPIBatteryManager kext, start the laptop without power chord the first boot from then it works.